### PR TITLE
The correct ecosystem name for go is golang

### DIFF
--- a/src/bomsquad/vulndb/matcher/factory.py
+++ b/src/bomsquad/vulndb/matcher/factory.py
@@ -22,7 +22,7 @@ class VersionFactory:
             return PypiVersion(spec)
         elif ecosystem == "maven":
             return MavenVersion(spec)
-        elif ecosystem == "go":
+        elif ecosystem == "golang":
             return GolangVersion(spec)
         elif ecosystem == "nuget":
             return NugetVersion(spec)


### PR DESCRIPTION
Test it with:
`vulndb purl lookup pkg:golang/github.com/graphql-go/graphql@0.8.0`