### PR TITLE
- Store datetime in microseconds as integer:

### DIFF
--- a/src/bomsquad/vulndb/db/connection.py
+++ b/src/bomsquad/vulndb/db/connection.py
@@ -20,17 +20,17 @@ class ConnectionFactory:
     _writable: Any = None
 
     @classmethod
-    def _adapt_timestamp(cls, value: datetime) -> int:
+    def _adapt_timestamp(cls, value: datetime) -> float:
         dt = value
 
         if value.tzinfo is None:
             dt = value.replace(tzinfo=timezone.utc)
 
-        return int(dt.timestamp() * 1000000)
+        return dt.timestamp()
 
     @classmethod
     def _convert_timestamp(cls, value: bytes) -> datetime:
-        return datetime.fromtimestamp(int(value) / 1000000, timezone.utc)
+        return datetime.fromtimestamp(float(value), timezone.utc)
 
     @classmethod
     def _adapt_json_data(cls, value: Dict[str, Any]) -> str:

--- a/src/bomsquad/vulndb/db/connection.py
+++ b/src/bomsquad/vulndb/db/connection.py
@@ -3,6 +3,7 @@ import logging
 import sqlite3
 from contextlib import contextmanager
 from datetime import datetime
+from datetime import timezone
 from threading import local
 from typing import Any
 from typing import cast
@@ -19,12 +20,17 @@ class ConnectionFactory:
     _writable: Any = None
 
     @classmethod
-    def _adapt_timestamp(cls, value: datetime) -> float:
-        return value.timestamp()
+    def _adapt_timestamp(cls, value: datetime) -> int:
+        dt = value
+
+        if value.tzinfo is None:
+            dt = value.replace(tzinfo=timezone.utc)
+
+        return int(dt.timestamp() * 1000000)
 
     @classmethod
     def _convert_timestamp(cls, value: bytes) -> datetime:
-        return datetime.fromtimestamp(float(value))
+        return datetime.fromtimestamp(int(value) / 1000000, timezone.utc)
 
     @classmethod
     def _adapt_json_data(cls, value: Dict[str, Any]) -> str:

--- a/src/bomsquad/vulndb/db/osvdb.py
+++ b/src/bomsquad/vulndb/db/osvdb.py
@@ -158,5 +158,14 @@ class OSVDB:
                 if not found_one:
                     raise RecordNotFoundError(f"No records found for id/alias {id}")
 
+    def find_by_id(self, id: str) -> OpenSSF:
+        with factory.get() as conn:
+            cursor = conn.cursor()
+            cursor.execute("SELECT osv.id, osv.data FROM osv WHERE osv.id=?", [id])
+            for id, data in cursor.fetchall():
+                return self._materialize_openssf(data)
+            else:
+                raise RecordNotFoundError(f"No records found for id/alias {id}")
+
 
 instance = OSVDB()

--- a/tests/unit/db/test_nvddb.py
+++ b/tests/unit/db/test_nvddb.py
@@ -1,6 +1,7 @@
 import logging
 from contextlib import AbstractContextManager
 from contextlib import nullcontext as does_not_raise
+from datetime import datetime
 from pathlib import Path
 from uuid import UUID
 
@@ -57,7 +58,7 @@ class TestNVDDB:
     def test_cve_last_modified(self) -> None:
         last_modified = nvddb.cve_last_modified()
         assert last_modified
-        assert last_modified.isoformat() == "2023-10-28T19:15:38.643000"
+        assert last_modified == datetime.fromisoformat("2023-10-28T19:15:38.643000Z")
 
     @pytest.mark.parametrize(
         ("id", "expectation"),
@@ -100,4 +101,4 @@ class TestNVDDB:
     def test_cpe_last_modified(self) -> None:
         last_modified = nvddb.cpe_last_modified()
         assert last_modified
-        assert last_modified.isoformat() == "2023-10-31T15:21:10.153000"
+        assert last_modified == datetime.fromisoformat("2023-10-31T15:21:10.153000Z")

--- a/tests/unit/db/test_nvddb.py
+++ b/tests/unit/db/test_nvddb.py
@@ -58,7 +58,9 @@ class TestNVDDB:
     def test_cve_last_modified(self) -> None:
         last_modified = nvddb.cve_last_modified()
         assert last_modified
-        assert last_modified == datetime.fromisoformat("2023-10-28T19:15:38.643000Z")
+        assert last_modified.replace(microsecond=0) == datetime.fromisoformat(
+            "2023-10-28T19:15:38Z"
+        )
 
     @pytest.mark.parametrize(
         ("id", "expectation"),
@@ -101,4 +103,6 @@ class TestNVDDB:
     def test_cpe_last_modified(self) -> None:
         last_modified = nvddb.cpe_last_modified()
         assert last_modified
-        assert last_modified == datetime.fromisoformat("2023-10-31T15:21:10.153000Z")
+        assert last_modified.replace(microsecond=0) == datetime.fromisoformat(
+            "2023-10-31T15:21:10Z"
+        )

--- a/tests/unit/db/test_osvdb.py
+++ b/tests/unit/db/test_osvdb.py
@@ -112,16 +112,18 @@ class TestOSVDB:
     def test_last_modified(self) -> None:
         last_modified = osvdb.last_modified()
         assert last_modified
-        assert last_modified == datetime.fromisoformat("2023-10-27T05:25:38.402707Z")
+        assert last_modified.replace(microsecond=0) == datetime.fromisoformat(
+            "2023-10-27T05:25:38Z"
+        )
 
     def test_last_modified_in_ecosystem(self, osv_examples: Path) -> None:
         expected = {
-            "crates.io": datetime.fromisoformat("2023-10-27T05:25:38.402707Z"),
+            "crates.io": datetime.fromisoformat("2023-10-27T05:25:38Z"),
             "conan": None,
         }
         for ecosystem in expected.keys():
             last_modified = osvdb.last_modified_in_ecosystem(ecosystem)
             if last_modified:
-                assert last_modified == expected[ecosystem]
+                assert last_modified.replace(microsecond=0) == expected[ecosystem]
             else:
                 assert expected[ecosystem] is None

--- a/tests/unit/db/test_osvdb.py
+++ b/tests/unit/db/test_osvdb.py
@@ -1,6 +1,7 @@
 import logging
 from contextlib import AbstractContextManager
 from contextlib import nullcontext as does_not_raise
+from datetime import datetime
 from pathlib import Path
 from typing import List
 
@@ -98,16 +99,16 @@ class TestOSVDB:
     def test_last_modified(self) -> None:
         last_modified = osvdb.last_modified()
         assert last_modified
-        assert last_modified.isoformat() == "2023-10-27T01:25:38.402710"
+        assert last_modified == datetime.fromisoformat("2023-10-27T05:25:38.402707Z")
 
     def test_last_modified_in_ecosystem(self, osv_examples: Path) -> None:
         expected = {
-            "crates.io": "2023-10-27T01:25:38.402710",
+            "crates.io": datetime.fromisoformat("2023-10-27T05:25:38.402707Z"),
             "conan": None,
         }
         for ecosystem in expected.keys():
             last_modified = osvdb.last_modified_in_ecosystem(ecosystem)
             if last_modified:
-                assert last_modified.isoformat() == expected[ecosystem]
+                assert last_modified == expected[ecosystem]
             else:
                 assert expected[ecosystem] is None

--- a/tests/unit/db/test_osvdb.py
+++ b/tests/unit/db/test_osvdb.py
@@ -35,6 +35,19 @@ class TestOSVDB:
                 assert osv.id == id or id in osv.aliases
 
     @pytest.mark.parametrize(
+        ("id", "expectation"),
+        [
+            ("GHSA-9xjr-m6f3-v5wm", does_not_raise()),
+            ("CVE-1968-4242", pytest.raises(RecordNotFoundError)),
+        ],
+    )
+    def test_find_by_id(self, id: str, expectation: AbstractContextManager[Exception]) -> None:
+        with expectation:
+            osv = osvdb.find_by_id(id)
+            assert isinstance(osv, OpenSSF)
+            assert osv.id == id
+
+    @pytest.mark.parametrize(
         ("purl", "expected_ids"), [("pkg:cargo/libwebp-sys2", ["GHSA-j7hp-h8jx-5ppr"])]
     )
     def test_find_by_purl(self, purl: str, expected_ids: List[str]) -> None:

--- a/tests/unit/matcher/test_version_factory.py
+++ b/tests/unit/matcher/test_version_factory.py
@@ -13,7 +13,7 @@ class TestVersionFactory:
             ("npm", "1.0", does_not_raise()),
             ("pypi", "42.0.3", does_not_raise()),
             ("maven", "1.0", does_not_raise()),
-            ("go", "1.0", does_not_raise()),
+            ("golang", "1.0", does_not_raise()),
             ("nuget", "1.0", does_not_raise()),
             ("npm", "1.0", does_not_raise()),
             ("cargo", "1.0", does_not_raise()),


### PR DESCRIPTION
    "SQLite promises to preserve the 15 most significant digits of a floating point value."
    https://www.sqlite.org/floatingpoint.html
- Store datetime in UTC time zone
- Fixed a bug in a test case: The correct ecosystem name for go is golang