### PR TITLE
Fix/remove update

### DIFF
--- a/src/bomsquad/vulndb/cli/ingest.py
+++ b/src/bomsquad/vulndb/cli/ingest.py
@@ -11,12 +11,11 @@ osv_app = typer.Typer(name="osv")
 @nvd_app.command(name="ingest")
 def _nvd_ingest(
     scope: Optional[str] = typer.Option(default=None, help="Ingest only cve or cpe "),
-    update: bool = typer.Option(default=False, help="Acquire records newer than current data"),
 ) -> None:
     if scope == "cve" or scope is None:
-        Ingest.cve(update=update)
+        Ingest.cve()
     if scope == "cpe" or scope is None:
-        Ingest.cpe(update=update)
+        Ingest.cpe()
 
 
 @osv_app.command(name="ingest")

--- a/src/bomsquad/vulndb/db/ingest.py
+++ b/src/bomsquad/vulndb/db/ingest.py
@@ -53,13 +53,12 @@ class Ingest:
     @classmethod
     def cve(
         cls,
-        update: bool = False,
     ) -> None:
         api = NVD()
         cp = Checkpoints()
         gen = _NVDResultGen(
             api.vulnerabilities(
-                offset=0, last_mod_start_date=cp.last_updated("cve") if update else None
+                offset=0, last_mod_start_date=cp.last_updated("cve")
             )
         )
 
@@ -71,12 +70,13 @@ class Ingest:
     @classmethod
     def cpe(
         cls,
-        update: bool = False,
     ) -> None:
         api = NVD()
         cp = Checkpoints()
         gen = _NVDResultGen(
-            api.products(offset=0, last_mod_start_date=cp.last_updated("cpe") if update else None)
+            api.products(
+                offset=0, last_mod_start_date=cp.last_updated("cpe")
+            )
         )
 
         if not gen.empty:

--- a/src/bomsquad/vulndb/db/ingest.py
+++ b/src/bomsquad/vulndb/db/ingest.py
@@ -57,9 +57,7 @@ class Ingest:
         api = NVD()
         cp = Checkpoints()
         gen = _NVDResultGen(
-            api.vulnerabilities(
-                offset=0, last_mod_start_date=cp.last_updated("cve")
-            )
+            api.vulnerabilities(offset=0, last_mod_start_date=cp.last_updated("cve"))
         )
 
         if not gen.empty:
@@ -73,11 +71,7 @@ class Ingest:
     ) -> None:
         api = NVD()
         cp = Checkpoints()
-        gen = _NVDResultGen(
-            api.products(
-                offset=0, last_mod_start_date=cp.last_updated("cpe")
-            )
-        )
+        gen = _NVDResultGen(api.products(offset=0, last_mod_start_date=cp.last_updated("cpe")))
 
         if not gen.empty:
             for cpe in gen:

--- a/tests/unit/db/test_ingest.py
+++ b/tests/unit/db/test_ingest.py
@@ -39,7 +39,7 @@ class TestIngest:
             vulns.return_value = iter(cves)
             with patch("bomsquad.vulndb.db.ingest.Checkpoints.upsert") as cp_upsert:
                 with patch("bomsquad.vulndb.db.ingest.nvddb.upsert_cve") as upsert_cve:
-                    Ingest.cve(update=update)
+                    Ingest.cve()
                     assert vulns.call_count == 1
                     args, kwargs = vulns.call_args
                     assert kwargs["offset"] == 0
@@ -69,7 +69,7 @@ class TestIngest:
             products.return_value = iter(cpes)
             with patch("bomsquad.vulndb.db.ingest.Checkpoints.upsert") as cp_upsert:
                 with patch("bomsquad.vulndb.db.ingest.nvddb.upsert_cpe") as upsert_cpe:
-                    Ingest.cpe(update=update)
+                    Ingest.cpe()
                     assert products.call_count == 1
                     args, kwargs = products.call_args
                     assert kwargs["offset"] == 0

--- a/tests/unit/db/test_ingest.py
+++ b/tests/unit/db/test_ingest.py
@@ -28,8 +28,7 @@ class TestIngest:
         for cve in nvddb.cve_all():
             assert isinstance(cve, CVE)
 
-    @pytest.mark.parametrize("update", [False, True])
-    def test_cve_api_args(self, update: bool) -> None:
+    def test_cve_api_args(self) -> None:
         examples = Path(__file__).parent / "examples/nvd/cve/"
         cves = [
             CVEResultSet("vulnerabilities", json.loads(path.read_text()), None)
@@ -44,10 +43,7 @@ class TestIngest:
                     args, kwargs = vulns.call_args
                     assert kwargs["offset"] == 0
                     cp = Checkpoints()
-                    if update:
-                        assert kwargs["last_mod_start_date"] == cp.last_updated("cve")
-                    else:
-                        assert kwargs["last_mod_start_date"] is None
+                    assert kwargs["last_mod_start_date"] == cp.last_updated("cve")
                     args, kwargs = cp_upsert.call_args
                     assert args[0] == "cve"
                     assert args[1] == cves[0].timestamp
@@ -74,10 +70,7 @@ class TestIngest:
                     args, kwargs = products.call_args
                     assert kwargs["offset"] == 0
                     cp = Checkpoints()
-                    if update:
-                        assert kwargs["last_mod_start_date"] == cp.last_updated("cpe")
-                    else:
-                        assert kwargs["last_mod_start_date"] is None
+                    assert kwargs["last_mod_start_date"] == cp.last_updated("cpe")
                     args, kwargs = cp_upsert.call_args
                     assert args[0] == "cpe"
                     assert args[1] == cpes[0].timestamp


### PR DESCRIPTION
It doesn't look like the update boolean is required and running the ingest solely based on the offset's last start date will, in effect, give the same result as having the update flag set. If it's empty, it will start at 0 and populate the entire db. If it's populated already, it will begin based on last entry.